### PR TITLE
fix(vorp_police/client/main.lua): avoid unnecessary drag reset when r…

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -14,7 +14,6 @@ local prompt           = 0
 AddEventHandler("onResourceStop", function(resource)
     if resource ~= GetCurrentResourceName() then return end
     if drag then
-        drag = false
         DetachEntity(PlayerPedId(), true, false)
     end
     -- remove blips


### PR DESCRIPTION
The drag variable is automatically cleared when the resource stops. Resetting it manually was redundant and unnecessary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts
